### PR TITLE
Make the name of env variables variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ add_compile_options(-Wall -Wextra -pedantic -march=native -std=gnu2x) #-Weveryth
 
 add_executable(updateip dynamicprefixvici.c)
 
-target_link_libraries(updateip /usr/local/lib/ipsec/libvici.so)
+target_link_libraries(updateip /usr/lib64/ipsec/libvici.so)
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(updateip VERSION 0.1.0)
 include(CTest)
 enable_testing()
 
-add_compile_options(-Wall -Wextra -pedantic -Weverything -march=native -std=c2x) #-Weverything -fanalyzer
+add_compile_options(-Wall -Wextra -pedantic -march=native -std=gnu2x) #-Weverything -fanalyzer
 
 add_executable(updateip dynamicprefixvici.c)
 

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -31,8 +31,8 @@ static char* getEnvironmentValue(const char* value);
 static vici_req_t* createMessage(char* poolName, char* addressPool);
 
 /**
- * @brief get all command line arguments an passes gives it back in a struct.
- * If unsupportet arguments are given, it terminates the program
+ * @brief get all command line arguments and gives it back in a struct.
+ * If unsupported arguments are given, it terminates the program
  * 
  * @param argc 
  * @param argv 
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
     // Set default values
     char* newPrefixEnv = "new_dhcp6_ia_pd1_prefix1";
     char* oldPrefixEnv = "old_dhcp6_ia_pd1_prefix1";
-    char* poolName = "global-ipv6";
+    char* poolName;
     
     if(arguments.newPrefixEnv != NULL)
     {
@@ -197,7 +197,7 @@ static vici_req_t* createMessage(char* poolName, char* addressPool)
 static void ParseCommandLineArguments(int argc, char** argv, CommandLineArguments* arguments)
 {
     int opt;
-    opterr = 0; // getopt moet zelf geen foutmelding geven
+    opterr = 0; // no error message by getopt
     arguments->poolName = NULL;
     arguments->newPrefixEnv = NULL;
     arguments->oldPrefixEnv = NULL;
@@ -228,5 +228,14 @@ static void ParseCommandLineArguments(int argc, char** argv, CommandLineArgument
             exit(1);
             break;
         }
+    }
+
+    // Check whether a pool name is defined
+    if(arguments->poolName == NULL)
+    {
+        // No pool name was defined
+
+        puts("Pool name has to be defined with -h <pool name>");
+        exit(1);
     }
 }

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -3,6 +3,15 @@
 #include <string.h>
 #include <errno.h>
 #include <libvici.h>
+#include <unistd.h>
+
+typedef struct CommandLineArguments
+{
+    char* poolName;
+    char* oldPrefixEnv;
+    char* newPrefixEnv;
+} CommandLineArguments;
+
 
 /**
   * @brief Retrieves a given environment value by name and places it in an allocated place in memory
@@ -21,12 +30,44 @@ static char* getEnvironmentValue(const char* value);
 */
 static vici_req_t* createMessage(char* poolName, char* addressPool);
 
-int main(void)
-{
-    char* newPrefix = getEnvironmentValue("new_dhcp6_ia_pd1_prefix1");
-    char* oldPrefix = getEnvironmentValue("old_dhcp6_ia_pd1_prefix1");
-    char* poolName = "global-ipv6";
+/**
+ * @brief get all command line arguments an passes gives it back in a struct.
+ * If unsupportet arguments are given, it terminates the program
+ * 
+ * @param argc 
+ * @param argv 
+ * @param arguments 
+ */
+static void ParseCommandLineArguments(int argc, char** argv, CommandLineArguments* arguments);
 
+int main(int argc, char** argv)
+{
+    // Parse command line arguments
+    CommandLineArguments arguments;
+    ParseCommandLineArguments(argc, argv, &arguments);
+
+    // Set default values
+    char* newPrefixEnv = "new_dhcp6_ia_pd1_prefix1";
+    char* oldPrefixEnv = "old_dhcp6_ia_pd1_prefix1";
+    char* poolName = "global-ipv6";
+    
+    if(arguments.newPrefixEnv != NULL)
+    {
+        newPrefixEnv = arguments.newPrefixEnv;
+    }
+    if(arguments.oldPrefixEnv != NULL)
+    {
+        oldPrefixEnv = arguments.oldPrefixEnv;
+    }
+    if(arguments.poolName != NULL)
+    {
+        poolName = arguments.poolName;
+    }
+
+    // Get environment values
+    char* newPrefix = getEnvironmentValue(newPrefixEnv);
+    char* oldPrefix = getEnvironmentValue(oldPrefixEnv);
+    
     // 20kB of space in memory to compose a message
     // A place in memory where the diagnostic message can be stored
     char betweenMessage[4096] = {0};
@@ -151,4 +192,41 @@ static vici_req_t* createMessage(char* poolName, char* addressPool)
     vici_end_section(message);
 
     return message;
+}
+
+static void ParseCommandLineArguments(int argc, char** argv, CommandLineArguments* arguments)
+{
+    int opt;
+    opterr = 0; // getopt moet zelf geen foutmelding geven
+    arguments->poolName = NULL;
+    arguments->newPrefixEnv = NULL;
+    arguments->oldPrefixEnv = NULL;
+
+    while((opt = getopt(argc, argv, ":p:n:o:h")) != -1)
+    {
+        switch (opt)
+        {
+        case 'h':// Help
+            puts("Supported arguments:\n-h Help massage\n-p <pool name> sets pool name\n-n <new prefix environment variable name> set name of environment variable which contains new prefix\n-o <old prefix environment variable name> set name of environment variable which contains old prefix");
+            exit(1);
+            break;
+        case 'p': // Pool name
+            arguments->poolName = optarg;
+            break;
+        case 'n':
+            arguments->newPrefixEnv = optarg;
+            break;
+        case 'o':
+            arguments->oldPrefixEnv = optarg;
+            break;
+        case ':':
+            puts("All options require arguments");
+            exit(1);
+            break;
+        case '?':
+            puts("Unrecognized argument");
+            exit(1);
+            break;
+        }
+    }
 }


### PR DESCRIPTION
Fixes #3
Fixes #1
Adds ability to set the name of the environment variable of the old and new prefix end to set the name of the pool.
Old values remain if nothing is set.
Could have been better if argp was availible.