### PR TITLE
Do something with the parsed return message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ add_compile_options(-Wall -Wextra -pedantic -march=native -std=gnu2x) #-Weveryth
 
 add_executable(updateip dynamicprefixvici.c)
 
-target_link_libraries(updateip /usr/local/lib/ipsec/libvici.so m)
+target_link_libraries(updateip /usr/local/lib/ipsec/libvici.so)
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,14 @@
 cmake_minimum_required(VERSION 3.0.0)
-project(updateip VERSION 0.1.0)
+project(dynamicprefixvici VERSION 0.1.0)
 
 include(CTest)
 enable_testing()
 
 add_compile_options(-Wall -Wextra -pedantic -march=native -std=gnu2x) #-Weverything -fanalyzer
 
-add_executable(updateip dynamicprefixvici.c)
+add_executable(dynamicprefixvici dynamicprefixvici.c)
 
-target_link_libraries(updateip /usr/local/lib/ipsec/libvici.so)
+target_link_libraries(dynamicprefixvici /usr/local/lib/ipsec/libvici.so)
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build:
+	clang dynamicprefixvici.c /usr/local/lib/ipsec/libvici.so -I/usr/local/include -Ofast -march=native -odynamicprefixvici
+
+install:
+	install -g wheel -o root -s dynamicprefixvici /usr/local/sbin

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ CC?=			cc
 INSTALL?=		install
 MAKE?=			make
 PREFIX?=		/usr/local
+RM?=			rm
 
 CFLAGS?=		-Ofast -march=native
 INCLUDEDIR?=	${PREFIX}/include
@@ -13,6 +14,9 @@ LIBS?=			${PREFIX}/lib/ipsec/libvici.so
 
 build:
 	${CC} ${SRC} ${LIBS} -I${INCLUDEDIR} ${CFLAGS} -o${PROG}
+
+clean:
+	${RM} -f ${PROG} ${PROG}.core
 
 install:
 	${INSTALL} -g wheel -o root -s ${PROG} ${INSTALLDIR}

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 PROG=   dynamicprefixvici
 SRC=    dynamicprefixvici.c
 
-CC?=            cc
+CC?=			cc
 INSTALL?=		install
-MAKE?=          make
-PREFIX?=        /usr/local
+MAKE?=			make
+PREFIX?=		/usr/local
 
-CFLAGS?=        -Ofast -march=native
-INCLUDEDIR?=    ${PREFIX}/include
-INSTALLDIR?=    ${PREFIX}/sbin
-LIBS?=          ${PREFIX}/lib/ipsec/libvici.so
+CFLAGS?=		-Ofast -march=native
+INCLUDEDIR?=	${PREFIX}/include
+INSTALLDIR?=	${PREFIX}/sbin
+LIBS?=			${PREFIX}/lib/ipsec/libvici.so
 
 build:
 	${CC} ${SRC} ${LIBS} -I${INCLUDEDIR} ${CFLAGS} -o${PROG}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,18 @@
+PROG=   dynamicprefixvici
+SRC=    dynamicprefixvici.c
+
+CC?=            cc
+INSTALL?=		install
+MAKE?=          make
+PREFIX?=        /usr/local
+
+CFLAGS?=        -Ofast -march=native
+INCLUDEDIR?=    ${PREFIX}/include
+INSTALLDIR?=    ${PREFIX}/sbin
+LIBS?=          ${PREFIX}/lib/ipsec/libvici.so
+
 build:
-	clang dynamicprefixvici.c /usr/local/lib/ipsec/libvici.so -I/usr/local/include -Ofast -march=native -odynamicprefixvici
+	${CC} ${SRC} ${LIBS} -I${INCLUDEDIR} ${CFLAGS} -o${PROG}
 
 install:
-	install -g wheel -o root -s dynamicprefixvici /usr/local/sbin
+	${INSTALL} -g wheel -o root -s ${PROG} ${INSTALLDIR}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PROG=   dynamicprefixvici
-SRC=    dynamicprefixvici.c
+PROG=	dynamicprefixvici
+SRC=	dynamicprefixvici.c
 
 CC?=			cc
 INSTALL?=		install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Building
-Before running build.sh, make sure libvici.h is present, typically shipped withh strongSwan.
+Before running build.sh, make sure libvici.h is present, typically shipped withh strongSwan.<br/>
 The following command should do the trick: *pkg install strongswan*
 
 
@@ -8,6 +8,6 @@ Add something like this to */usr/local/etc/dhcpcd.exit-hook*
 
 case "$reason" in  
 BOUND6|RENEW6|REBIND6|REBOOT6|INFORM6)  
-&nbsp;&nbsp;&nbsp;&nbsp;prefix=$(printenv new_dhcp6_ia_pd1_prefix1)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;prefix=$(printenv new_dhcp6_ia_pd1_prefix1)<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;/usr/local/sbin/dynamicprefixvici -p "$prefix" -n "global-ipv6"  
 esac

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Building
-Before running build.sh, make sure strongswan is installed with the libvici.h.
+Before running build.sh, make sure libvici.h is present, typically shipped withh strongSwan.
 The following command should do the trick: *pkg install strongswan*
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Building
-Before running build.sh, make sure libvici.h is present, typically shipped with strongSwan.<br/>
+Before building, make sure libvici.h is present, typically shipped with strongSwan.<br/>
 The following command should do the trick: *pkg install strongswan*
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Building
-Before running build.sh, make sure libvici.h is present, typically shipped withh strongSwan.<br/>
+Before running build.sh, make sure libvici.h is present, typically shipped with strongSwan.<br/>
 The following command should do the trick: *pkg install strongswan*
 
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
-clang dynamicprefixvici.c /usr/local/lib/ipsec/libvici.so /usr/lib/libm.so \
-    -I/usr/local/include -I/usr/lib/include \
+clang dynamicprefixvici.c \
+    /usr/local/lib/ipsec/libvici.so \
+    -I/usr/local/include \
     -Ofast -march=native -odynamicprefixvici

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-clang dynamicprefixvici.c \
-    /usr/local/lib/ipsec/libvici.so \
-    -I/usr/local/include \
-    -Ofast -march=native -odynamicprefixvici

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -152,7 +152,7 @@ static void FormatOutput(CommandLineArguments* arguments, char* address_pool)
     // Append the pool size to the address
     strcpy(address_pool, arguments->prefix_address);
 
-    size_t length_string = strlen(output);
+    size_t length_string = strlen(address_pool);
     sprintf(&address_pool[length_string], "/%s", arguments->pool_size);
 }
 

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -31,7 +31,7 @@ static vici_req_t* CreateLoadPoolMessage(char* pool_name, char* address_pool);
 static void FormatOutput(CommandLineArguments* arguments, char* address_pool);
 
 /**
- * @brief Get all command line arguments and gives it back in a struct.
+ * @brief Get all command line arguments and gives it back in a struct
  * If unsupported arguments are given, it terminates the program
  *
  * @param argc
@@ -48,33 +48,30 @@ static void Usage();
 
 int main(int argc, char** argv)
 {
-    // For diagnostic reasons
-    bool error_encountered = false;
-
-    // Parse command line arguments
+    // parse command line arguments
     CommandLineArguments arguments;
     ParseCommandLineArguments(argc, argv, &arguments);
 
-    // Create address_pool to be sent
+    // create address_pool to be sent
     char address_pool[50] = {0};
     FormatOutput(&arguments, address_pool);
     printf("address_pool: %s\n", address_pool);
 
-    // Initialize vici library
+    // initialize vici library
     vici_init();
     
-    // Create load-pool message
+    // create load-pool message
     vici_req_t* load_pool_message = CreateLoadPoolMessage(arguments.pool_name, address_pool);
 
-    // Open connection, assume the system is the standard connection
+    // open connection, assume the system is the standard connection
     vici_conn_t* connection = vici_connect(NULL);
 
     if(connection != NULL)
     {
-        // Connection has been made, forward message
+        // connection has been made, forward message
         vici_res_t* response = vici_submit(load_pool_message, connection);
 
-        // Check if the message has been sent correctly
+        // check if the message has been sent correctly
         if(response == NULL)
         {
             printf("Unable to send the message: %s\n", strerror(errno));
@@ -99,7 +96,6 @@ int main(int argc, char** argv)
             }
             else
             {
-                // Unable to parse other than file
                 parsed_message = "ERROR: Unable to parse return message";
             }
 
@@ -134,10 +130,10 @@ static vici_req_t* CreateLoadPoolMessage(char* pool_name, char* address_pool)
 
 static void FormatOutput(CommandLineArguments* arguments, char* address_pool)
 {
-    // Append the pool size to the address
+    // copy the prefix_address to the address_pool
     strcpy(address_pool, arguments->prefix_address);
-
     size_t length_string = strlen(address_pool);
+    // append a "/" with the pool_size
     sprintf(&address_pool[length_string], "/%s", arguments->pool_size);
 }
 
@@ -174,7 +170,7 @@ static void ParseCommandLineArguments(int argc, char** argv, CommandLineArgument
         }
     }
 
-    // Check whether a pool_name and a prefix_address are defined
+    // check whether a pool_name and a prefix_address are defined
     if(arguments->pool_name == NULL || arguments->prefix_address == NULL)
     {
         puts("pool_name and prefix_address are required, see -h for usage");

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -54,15 +54,9 @@ int main(int argc, char** argv)
     // Parse command line arguments
     CommandLineArguments arguments;
     ParseCommandLineArguments(argc, argv, &arguments);
-    
-    // 20kB of space in memory to compose a message
-    // A place in memory where the diagnostic message can be stored
-    char between_message[4096] = {0};
-    char diagnostic_message[16384] = {0};
 
     // Add new prefix_address to diagnostic message
-    sprintf(between_message, "prefix_address: %s\n", arguments.prefix_address);
-    strcat(diagnostic_message, between_message);
+    printf("prefix_address: %s\n", arguments.prefix_address);
 
     // Initialize vici library
     vici_init();
@@ -71,8 +65,7 @@ int main(int argc, char** argv)
     char address_pool[50] = {0};
     FormatOutput(&arguments, address_pool);
     
-    sprintf(between_message, "address_pool: %s\n", address_pool);
-    strcat(diagnostic_message, between_message);
+    printf("address_pool: %s\n", address_pool);
 
     vici_req_t* load_pool_message = CreateLoadPoolMessage(arguments.pool_name, address_pool);
 
@@ -87,8 +80,7 @@ int main(int argc, char** argv)
         // Check if the message has been sent correctly
         if(response == NULL)
         {
-            sprintf(between_message, "Status: Unable to send the message: %s\n", strerror(errno));
-            strcat(diagnostic_message, between_message);
+            printf("Status: Unable to send the message: %s\n", strerror(errno));
         }
         else
         {
@@ -114,8 +106,7 @@ int main(int argc, char** argv)
                 parsed_message = "ERROR: Unable to parse";
             }
 
-            sprintf(between_message, "Received message: %s\n", parsed_message);
-            strcat(diagnostic_message, between_message);
+            printf("Received message: %s\n", parsed_message);
         }
 
         vici_disconnect(connection);
@@ -123,11 +114,9 @@ int main(int argc, char** argv)
     else
     {
         // Add to dianogstic message
-        sprintf(between_message, "Status: Connection failed: %s\n", strerror(errno));
-        strcat(diagnostic_message, between_message);
+        printf("Status: Connection failed: %s\n", strerror(errno));
     }
 
-    puts(diagnostic_message);
     return 0;
 }
 

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -28,6 +28,14 @@ typedef struct CommandLineArguments
 static vici_req_t* CreateMessage(char* pool_name, char* address_pool);
 
 /**
+ * @brief Formats the output address to be given to vici
+ * 
+ * @param arguments 
+ * @param output 
+ */
+static void FormatOutput(CommandLineArguments* arguments, char* output);
+
+/**
  * @brief get all command line arguments and gives it back in a struct.
  * If unsupported arguments are given, it terminates the program
  *
@@ -41,14 +49,6 @@ static void ParseCommandLineArguments(int argc, char** argv, CommandLineArgument
  * @brief prints the usage of the program
  */
 static void Usage();
-
-/**
- * @brief Formats the output address to be given to vici
- * 
- * @param arguments 
- * @param output 
- */
-static void FormatOutput(CommandLineArguments* arguments, char* output);
 
 
 int main(int argc, char** argv)
@@ -152,6 +152,16 @@ static vici_req_t* CreateMessage(char* pool_name, char* address_pool)
     return message;
 }
 
+static void FormatOutput(CommandLineArguments* arguments, char* output)
+{
+    // Append the pool size to the address
+    strcpy(output, arguments->prefix_address);
+
+    size_t length_string = strlen(output);
+    sprintf(&output[length_string], "/%s", arguments->pool_size);
+
+}
+
 static void ParseCommandLineArguments(int argc, char** argv, CommandLineArguments* arguments)
 {
     int opt;
@@ -200,14 +210,4 @@ static void Usage()
             "-n pool_name: sets the pool name to add\n"
             "-p prefix_address: sets the prefix_address to add\n"
             "-s pool_size: size of the pool to add as decimal integer\n");
-}
-
-static void FormatOutput(CommandLineArguments* arguments, char* output)
-{
-    // Append the pool size to the address
-    strcpy(output, arguments->prefix_address);
-
-    size_t length_string = strlen(output);
-    sprintf(&output[length_string], "/%s", arguments->pool_size);
-
 }

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -107,6 +107,7 @@ int main(int argc, char** argv)
         printf("Connection failed: %s\n", strerror(errno));
     }
 
+    puts(diagnostic_message);
     return 0;
 }
 

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -2,10 +2,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <math.h>
-#include <ctype.h>
-#include <stdint.h>
-#include <stdbool.h>
 
 #include <unistd.h>
 

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -154,7 +154,6 @@ static void FormatOutput(CommandLineArguments* arguments, char* output)
 
     size_t length_string = strlen(output);
     sprintf(&output[length_string], "/%s", arguments->pool_size);
-
 }
 
 static void ParseCommandLineArguments(int argc, char** argv, CommandLineArguments* arguments)

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -55,9 +55,6 @@ int main(int argc, char** argv)
     CommandLineArguments arguments;
     ParseCommandLineArguments(argc, argv, &arguments);
 
-    // Add new prefix_address to diagnostic message
-    printf("prefix_address: %s\n", arguments.prefix_address);
-
     // Initialize vici library
     vici_init();
 

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -28,7 +28,7 @@ static vici_req_t* CreateLoadPoolMessage(char* pool_name, char* address_pool);
  * @param arguments 
  * @param address_pool 
  */
-static void FormatOutput(CommandLineArguments* arguments, char* address_pool);
+static void FormatAddressPool(CommandLineArguments* arguments, char* address_pool);
 
 /**
  * @brief Get all command line arguments and gives it back in a struct
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
 
     // create address_pool to be sent
     char address_pool[50] = {0};
-    FormatOutput(&arguments, address_pool);
+    FormatAddressPool(&arguments, address_pool);
     printf("address_pool: %s\n", address_pool);
 
     // initialize vici library
@@ -128,7 +128,7 @@ static vici_req_t* CreateLoadPoolMessage(char* pool_name, char* address_pool)
     return message;
 }
 
-static void FormatOutput(CommandLineArguments* arguments, char* address_pool)
+static void FormatAddressPool(CommandLineArguments* arguments, char* address_pool)
 {
     // copy the prefix_address to the address_pool
     strcpy(address_pool, arguments->prefix_address);

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -180,7 +180,7 @@ static void ParseCommandLineArguments(int argc, char** argv, CommandLineArgument
 
 static void Usage()
 {
-    printf("usage: dynamicprefixvici [-h] -n pool_name -p prefix_address [-s pool_size[97]]\n"
+    puts("usage: dynamicprefixvici [-h] -n pool_name -p prefix_address [-s pool_size[97]]\n"
             "-h displays the usage message\n"
             "-n pool_name: sets the pool name to add\n"
             "-p prefix_address: sets the prefix_address to add\n"

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -138,7 +138,7 @@ static void FormatOutput(CommandLineArguments* arguments, char* address_pool)
     strcpy(address_pool, arguments->prefix_address);
 
     size_t length_string = strlen(address_pool);
-    sprintf(&address_pool[length_string], "/%s", arguments->pool_size);
+    strcat(&address_pool[length_string], arguments->pool_size);
 }
 
 static void ParseCommandLineArguments(int argc, char** argv, CommandLineArguments* arguments)

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -48,7 +48,7 @@ static void Usage();
 
 int main(int argc, char** argv)
 {
-    // parse command line arguments
+    // Parse command line arguments
     CommandLineArguments arguments;
     ParseCommandLineArguments(argc, argv, &arguments);
 
@@ -86,8 +86,6 @@ int main(int argc, char** argv)
                 // Let the program exit with 1 if vici was unable to add the pool
                 if(parsed_message[0] != 'y')
                 {
-                    error_encountered = true;
-
                     // Parse the error message from Vici
                     parsed_message = vici_parse_value_str(response);
                     puts(parsed_message);

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -28,7 +28,7 @@ static vici_req_t* CreateMessage(char* pool_name, char* address_pool);
  * @param arguments 
  * @param output 
  */
-static void FormatOutput(CommandLineArguments* arguments, char* output);
+static void FormatOutput(CommandLineArguments* arguments, char* address_pool);
 
 /**
  * @brief get all command line arguments and gives it back in a struct.

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -168,7 +168,7 @@ static void ParseCommandLineArguments(int argc, char** argv, CommandLineArgument
     opterr = 0; // no error message by getopt
     arguments->pool_name = NULL;
     arguments->prefix_address = NULL;
-    arguments->pool_size = "97";
+    arguments->pool_size = "97"; // this is the largest strongSwan can handle
 
     while((opt = getopt(argc, argv, ":p:n:s:h")) != -1)
     {

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -110,6 +110,7 @@ int main(int argc, char** argv)
                     // Parse the error message from Vici
                     parsed_message = vici_parse_value_str(response);
                     puts(parsed_message);
+                    exit(1);
                 }
             }
             else
@@ -129,21 +130,10 @@ int main(int argc, char** argv)
         // Add to dianogstic message
         sprintf(between_message, "Status: Connection failed: %s\n", strerror(errno));
         strcat(diagnostic_message, between_message);
-
-        // Let the program exit with 1 no connection could be made
-        error_encountered = true;
     }
 
     puts(diagnostic_message);
-    
-    if(error_encountered)
-    {
-        return 1;
-    }
-    else
-    {
-        return 0;
-    }
+    return 0;
 }
 
 static vici_req_t* CreateMessage(char* pool_name, char* address_pool)

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -106,6 +106,10 @@ int main(int argc, char** argv)
                 if(parsed_message[0] != 'y')
                 {
                     error_encountered = true;
+
+                    // Parse the error message from Vici
+                    parsed_message = vici_parse_value_str(response);
+                    puts(parsed_message);
                 }
             }
             else

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -180,7 +180,7 @@ static void ParseCommandLineArguments(int argc, char** argv, CommandLineArgument
 
 static void Usage()
 {
-    c("usage: dynamicprefixvici [-h] -n pool_name -p prefix_address [-s pool_size[97]]\n"
+    puts("usage: dynamicprefixvici [-h] -n pool_name -p prefix_address [-s pool_size[97]]\n"
             "-h displays the usage message\n"
             "-n pool_name: sets the pool name to add\n"
             "-p prefix_address: sets the prefix_address to add\n"

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -55,15 +55,15 @@ int main(int argc, char** argv)
     CommandLineArguments arguments;
     ParseCommandLineArguments(argc, argv, &arguments);
 
-    // Initialize vici library
-    vici_init();
-
     // Create address_pool to be sent
     char address_pool[50] = {0};
     FormatOutput(&arguments, address_pool);
-    
     printf("address_pool: %s\n", address_pool);
 
+    // Initialize vici library
+    vici_init();
+    
+    // Create load-pool message
     vici_req_t* load_pool_message = CreateLoadPoolMessage(arguments.pool_name, address_pool);
 
     // Open connection, assume the system is the standard connection

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -31,7 +31,7 @@ static vici_req_t* CreateLoadPoolMessage(char* pool_name, char* address_pool);
 static void FormatOutput(CommandLineArguments* arguments, char* address_pool);
 
 /**
- * @brief get all command line arguments and gives it back in a struct.
+ * @brief Get all command line arguments and gives it back in a struct.
  * If unsupported arguments are given, it terminates the program
  *
  * @param argc
@@ -41,7 +41,7 @@ static void FormatOutput(CommandLineArguments* arguments, char* address_pool);
 static void ParseCommandLineArguments(int argc, char** argv, CommandLineArguments* arguments);
 
 /**
- * @brief prints the usage of the program
+ * @brief Prints the usage of the program
  */
 static void Usage();
 

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -9,8 +9,8 @@
 typedef struct CommandLineArguments
 {
     char* pool_name;
-    char* prefix_address;
     char* pool_size;
+    char* prefix_address;
 } CommandLineArguments;
 
 /**
@@ -161,8 +161,8 @@ static void ParseCommandLineArguments(int argc, char** argv, CommandLineArgument
     int opt;
     opterr = 0; // no error message by getopt
     arguments->pool_name = NULL;
-    arguments->prefix_address = NULL;
     arguments->pool_size = "97"; // default chosen as the largest size strongSwan will add
+    arguments->prefix_address = NULL;
 
     while((opt = getopt(argc, argv, ":p:n:s:h")) != -1)
     {

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -147,13 +147,13 @@ static vici_req_t* CreateMessage(char* pool_name, char* address_pool)
     return message;
 }
 
-static void FormatOutput(CommandLineArguments* arguments, char* output)
+static void FormatOutput(CommandLineArguments* arguments, char* address_pool)
 {
     // Append the pool size to the address
-    strcpy(output, arguments->prefix_address);
+    strcpy(address_pool, arguments->prefix_address);
 
     size_t length_string = strlen(output);
-    sprintf(&output[length_string], "/%s", arguments->pool_size);
+    sprintf(&address_pool[length_string], "/%s", arguments->pool_size);
 }
 
 static void ParseCommandLineArguments(int argc, char** argv, CommandLineArguments* arguments)

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -100,7 +100,7 @@ int main(int argc, char** argv)
             else
             {
                 // Unable to parse other than file
-                parsed_message = "ERROR: Unable to parse";
+                parsed_message = "ERROR: Unable to parse return message";
             }
 
             printf("Received message: %s\n", parsed_message);

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -202,7 +202,7 @@ static void Usage()
             "-s pool_size: size of the pool to add as decimal integer\n");
 }
 
-void FormatOutput(CommandLineArguments* arguments, char* output)
+static void FormatOutput(CommandLineArguments* arguments, char* output)
 {
     // Append the pool size to the address
     strcpy(output, arguments->prefix_address);

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -110,7 +110,6 @@ int main(int argc, char** argv)
     }
     else
     {
-        // Add to dianogstic message
         printf("Status: Connection failed: %s\n", strerror(errno));
     }
 

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -77,7 +77,7 @@ int main(int argc, char** argv)
         // Check if the message has been sent correctly
         if(response == NULL)
         {
-            printf("Status: Unable to send the message: %s\n", strerror(errno));
+            printf("Unable to send the message: %s\n", strerror(errno));
         }
         else
         {
@@ -110,7 +110,7 @@ int main(int argc, char** argv)
     }
     else
     {
-        printf("Status: Connection failed: %s\n", strerror(errno));
+        printf("Connection failed: %s\n", strerror(errno));
     }
 
     return 0;

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -1,8 +1,7 @@
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
-
 #include <unistd.h>
 
 #include <libvici.h>

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -23,10 +23,10 @@ typedef struct CommandLineArguments
 static vici_req_t* CreateMessage(char* pool_name, char* address_pool);
 
 /**
- * @brief Formats the output address to be given to vici
+ * @brief Formats the address_pool to be given to vici
  * 
  * @param arguments 
- * @param output 
+ * @param address_pool 
  */
 static void FormatOutput(CommandLineArguments* arguments, char* address_pool);
 

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -53,6 +53,9 @@ void FormatOutput(CommandLineArguments* arguments, char* output);
 
 int main(int argc, char** argv)
 {
+    // For diagnostic reasons
+    bool error_encountered = false;
+
     // Parse command line arguments
     CommandLineArguments arguments;
     ParseCommandLineArguments(argc, argv, &arguments);
@@ -98,6 +101,12 @@ int main(int argc, char** argv)
             if(vici_parse(response) == VICI_PARSE_KEY_VALUE)
             {
                 parsed_message = vici_parse_value_str(response);
+
+                // Let the program exit with 1 if vici was unable to add the pool
+                if(parsed_message[0] != 'y')
+                {
+                    error_encountered = true;
+                }
             }
             else
             {
@@ -116,10 +125,21 @@ int main(int argc, char** argv)
         // Add to dianogstic message
         sprintf(between_message, "Status: Connection failed: %s\n", strerror(errno));
         strcat(diagnostic_message, between_message);
+
+        // Let the program exit with 1 no connection could be made
+        error_encountered = true;
     }
 
     puts(diagnostic_message);
-    return 0;
+    
+    if(error_encountered)
+    {
+        return 1;
+    }
+    else
+    {
+        return 0;
+    }
 }
 
 static vici_req_t* CreateMessage(char* pool_name, char* address_pool)

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -136,7 +136,9 @@ static void FormatOutput(CommandLineArguments* arguments, char* address_pool)
 {
     // Append the pool size to the address
     strcpy(address_pool, arguments->prefix_address);
-    sprintf(address_pool, "/%s", arguments->pool_size);
+
+    size_t length_string = strlen(address_pool);
+    sprintf(&address_pool[length_string], "/%s", arguments->pool_size);
 }
 
 static void ParseCommandLineArguments(int argc, char** argv, CommandLineArguments* arguments)

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -180,9 +180,9 @@ static void ParseCommandLineArguments(int argc, char** argv, CommandLineArgument
 
 static void Usage()
 {
-    puts("usage: dynamicprefixvici [-h] -n pool_name -p prefix_address [-s pool_size[97]]\n"
+    c("usage: dynamicprefixvici [-h] -n pool_name -p prefix_address [-s pool_size[97]]\n"
             "-h displays the usage message\n"
             "-n pool_name: sets the pool name to add\n"
             "-p prefix_address: sets the prefix_address to add\n"
-            "-s pool_size: size of the pool to add as decimal integer\n");
+            "-s pool_size: size of the pool to add as decimal integer");
 }

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -43,9 +43,9 @@ static void ParseCommandLineArguments(int argc, char** argv, CommandLineArgument
 static void Usage();
 
 /**
- * @brief Formats the output adress to be given to vici
+ * @brief Formats the output address to be given to vici
  * 
- * @param argumenten 
+ * @param arguments 
  * @param output 
  */
 void FormatOutput(CommandLineArguments* arguments, char* output);

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -168,7 +168,7 @@ static void ParseCommandLineArguments(int argc, char** argv, CommandLineArgument
     opterr = 0; // no error message by getopt
     arguments->pool_name = NULL;
     arguments->prefix_address = NULL;
-    arguments->pool_size = "97"; // this is the largest strongSwan can handle
+    arguments->pool_size = "97"; // default chosen as the largest size strongSwan will add
 
     while((opt = getopt(argc, argv, ":p:n:s:h")) != -1)
     {

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -136,9 +136,7 @@ static void FormatOutput(CommandLineArguments* arguments, char* address_pool)
 {
     // Append the pool size to the address
     strcpy(address_pool, arguments->prefix_address);
-
-    size_t length_string = strlen(address_pool);
-    sprintf(&address_pool[length_string], "/%s", arguments->pool_size);
+    sprintf(address_pool, "/%s", arguments->pool_size);
 }
 
 static void ParseCommandLineArguments(int argc, char** argv, CommandLineArguments* arguments)

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -138,7 +138,7 @@ static void FormatOutput(CommandLineArguments* arguments, char* address_pool)
     strcpy(address_pool, arguments->prefix_address);
 
     size_t length_string = strlen(address_pool);
-    strcat(&address_pool[length_string], arguments->pool_size);
+    sprintf(&address_pool[length_string], "/%s", arguments->pool_size);
 }
 
 static void ParseCommandLineArguments(int argc, char** argv, CommandLineArguments* arguments)

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -20,7 +20,7 @@ typedef struct CommandLineArguments
  * @param address_pool The address pool
  * @return vici_req_t* The message to send
  */
-static vici_req_t* CreateMessage(char* pool_name, char* address_pool);
+static vici_req_t* CreateLoadPoolMessage(char* pool_name, char* address_pool);
 
 /**
  * @brief Formats the address_pool to be given to vici
@@ -74,7 +74,7 @@ int main(int argc, char** argv)
     sprintf(between_message, "address_pool: %s\n", address_pool);
     strcat(diagnostic_message, between_message);
 
-    vici_req_t* message_to_send = CreateMessage(arguments.pool_name, address_pool);
+    vici_req_t* load_pool_message = CreateLoadPoolMessage(arguments.pool_name, address_pool);
 
     // Open connection, assume the system is the standard connection
     vici_conn_t* connection = vici_connect(NULL);
@@ -82,7 +82,7 @@ int main(int argc, char** argv)
     if(connection != NULL)
     {
         // Connection has been made, forward message
-        vici_res_t* response = vici_submit(message_to_send, connection);
+        vici_res_t* response = vici_submit(load_pool_message, connection);
 
         // Check if the message has been sent correctly
         if(response == NULL)
@@ -131,7 +131,7 @@ int main(int argc, char** argv)
     return 0;
 }
 
-static vici_req_t* CreateMessage(char* pool_name, char* address_pool)
+static vici_req_t* CreateLoadPoolMessage(char* pool_name, char* address_pool)
 {
     /*
     <pool name> = {

--- a/dynamicprefixvici.c
+++ b/dynamicprefixvici.c
@@ -48,7 +48,7 @@ static void Usage();
  * @param arguments 
  * @param output 
  */
-void FormatOutput(CommandLineArguments* arguments, char* output);
+static void FormatOutput(CommandLineArguments* arguments, char* output);
 
 
 int main(int argc, char** argv)

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-install -g wheel -o root -s dynamicprefixvici /usr/local/sbin


### PR DESCRIPTION
Fixes #14

No exit call because the diagnostic message wouldn't be printed.